### PR TITLE
Payment forking

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 The common-theory contracts, with an overview of use.
 
+- [`https://commontheory.io`](https://commontheory.io)
+- [`https://ipfs.io/ipns/commontheory.io`](https://ipfs.io/ipns/commontheory.io)
+- [![latest hash](https://dnslink-cid-badge.commontheory.io/commontheory.io)](https://dnslink-cid-badge.commontheory.io/commontheory.io?redirect=true)
+
 ## Syndicate
 
 ```
@@ -10,17 +14,20 @@ Syndicate
 noun - a group of individuals combined to promote some common interest
 ```
 
-Syndicates can be used to send payments over time between Ethereum addresses. Balances are held in the contract and funds are locked during transfer. Payments are guaranteed to complete once initiated.
-
 Syndicates are a means by which to improve **fairness** and **efficiency** in financial interaction.
 
-- [`https://commontheory.io`](https://commontheory.io)
-- [`https://ipfs.io/ipns/commontheory.io`](https://ipfs.io/ipns/commontheory.io)
-- [![latest hash](https://dnslink-cid-badge.commontheory.io/commontheory.io)](https://dnslink-cid-badge.commontheory.io/commontheory.io?redirect=true)
+### Payments
 
-### Proof
+Syndicates can be used to send payments over time between Ethereum addresses. Balances are held in the contract and funds are locked during transfer. Payments are guaranteed to complete once initiated.
+
+#### Proof
 
 A mathematical proof of the [`paymentWeiOwed`](https://github.com/common-theory/contracts/blob/master/contracts/Syndicate.sol#L79) function can be found [here](https://github.com/common-theory/contracts/blob/master/proofs/paymentWeiOwed.pdf).
+
+### Forks
+
+Once a payment has been initiated the recipient is able to fork some (or all) of the remaining payment to other addresses. A payment is ownership of a certain
+rate of wei/second and can be distributed between many addresses. A payment is delegation of responsibility for funds over time.
 
 ## Intended Use
 

--- a/contracts/Syndicate.sol
+++ b/contracts/Syndicate.sol
@@ -24,7 +24,7 @@ contract Syndicate {
   Payment[] public payments;
 
   // A mapping of Payment index to forked payments that have been created
-  mapping (uint256 => uint256[2]) public _forks;
+  mapping (uint256 => uint256[2]) public forkIndexes;
 
   event PaymentUpdated(uint256 index);
   event PaymentCreated(uint256 index);
@@ -123,7 +123,7 @@ contract Syndicate {
       isFork: true,
       parentIndex: index
     }));
-    _forks[index][0] = payments.length - 1;
+    forkIndexes[index][0] = payments.length - 1;
     emit PaymentCreated(payments.length - 1);
 
     payments.push(Payment({
@@ -136,13 +136,18 @@ contract Syndicate {
       isFork: true,
       parentIndex: index
     }));
-    _forks[index][1] = payments.length - 1;
+    forkIndexes[index][1] = payments.length - 1;
     emit PaymentCreated(payments.length - 1);
   }
 
   function paymentForkIndexes(uint256 index) public view returns (uint256[2] memory) {
     assertPaymentIndexInRange(index);
-    return _forks[index];
+    return forkIndexes[index];
+  }
+
+  function isPaymentForked(uint256 index) public view returns (bool) {
+    assertPaymentIndexInRange(index);
+    return forkIndexes[index][0] != 0 && forkIndexes[index][1] != 0;
   }
 
   /**

--- a/contracts/Syndicate.sol
+++ b/contracts/Syndicate.sol
@@ -27,6 +27,9 @@ contract Syndicate {
 
   Payment[] public payments;
 
+  // A mapping of Payment index to forked payments that have been created
+  mapping (uint256 => uint256[]) public forks;
+
   event PaymentUpdated(uint256 index);
   event PaymentCreated(uint256 index);
 
@@ -122,6 +125,7 @@ contract Syndicate {
       isFork: true,
       parentIndex: index
     }));
+    forks[index].push(payments.length - 1);
     emit PaymentUpdated(index);
     emit PaymentCreated(payments.length - 1);
   }

--- a/contracts/Syndicate.sol
+++ b/contracts/Syndicate.sol
@@ -1,13 +1,9 @@
 pragma solidity ^0.5.0;
 
 /**
- * The Syndicate contract
+ * Syndicate
  *
- * A way for distributed groups of people to work together and come to consensus
- * on use of funds.
- *
- * syndicate - noun
- * a group of individuals or syndicates combined to promote some common interest
+ * A way to distribute ownership of ether in time
  **/
 
 contract Syndicate {
@@ -130,6 +126,9 @@ contract Syndicate {
     emit PaymentCreated(payments.length - 1);
   }
 
+  /**
+   * Get the number of forks for the payment at index.
+   **/
   function paymentForkCount(uint256 index) public view returns (uint256) {
     assertPaymentIndexInRange(index);
     return _forks[index].length;

--- a/contracts/Syndicate.sol
+++ b/contracts/Syndicate.sol
@@ -112,24 +112,26 @@ contract Syndicate {
     // Payment at index
     payments[index].weiValue = payments[index].weiPaid;
     emit PaymentUpdated(index);
-    payments.push(Payment({
-      sender: payment.receiver,
-      receiver: payment.receiver,
-      timestamp: block.timestamp,
-      time: remainingTime,
-      weiValue: remainingWei - _weiValue,
-      weiPaid: 0,
-      isFork: true,
-      parentIndex: index
-    }));
-    emit PaymentCreated(payments.length - 1);
-    _forks[index][0] = payments.length - 1;
+
     payments.push(Payment({
       sender: msg.sender,
       receiver: _receiver,
       timestamp: block.timestamp,
       time: remainingTime,
       weiValue: _weiValue,
+      weiPaid: 0,
+      isFork: true,
+      parentIndex: index
+    }));
+    _forks[index][0] = payments.length - 1;
+    emit PaymentCreated(payments.length - 1);
+
+    payments.push(Payment({
+      sender: payment.receiver,
+      receiver: payment.receiver,
+      timestamp: block.timestamp,
+      time: remainingTime,
+      weiValue: remainingWei - _weiValue,
       weiPaid: 0,
       isFork: true,
       parentIndex: index

--- a/contracts/Syndicate.sol
+++ b/contracts/Syndicate.sol
@@ -94,9 +94,6 @@ contract Syndicate {
    * settled. Child payments can also be forked.
    **/
   function paymentFork(uint256 index, address payable _receiver, uint256 _weiValue) public {
-    // Settle the payment to the current point in time
-    paymentSettle(index);
-
     Payment memory payment = payments[index];
     // Make sure the payment owner is operating
     require(msg.sender == payment.receiver);

--- a/contracts/Syndicate.sol
+++ b/contracts/Syndicate.sol
@@ -21,6 +21,8 @@ contract Syndicate {
     uint256 time;
     uint256 weiValue;
     uint256 weiPaid;
+    bool isFork;
+    uint256 parentIndex;
   }
 
   Payment[] public payments;
@@ -50,7 +52,9 @@ contract Syndicate {
       timestamp: block.timestamp,
       time: _time,
       weiValue: _weiValue,
-      weiPaid: 0
+      weiPaid: 0,
+      isFork: false,
+      parentIndex: 0
     }));
     // Update the balance value of the sender to effectively lock the funds in place
     balances[msg.sender] -= _weiValue;
@@ -114,7 +118,9 @@ contract Syndicate {
       timestamp: block.timestamp,
       time: remainingTime,
       weiValue: _weiValue,
-      weiPaid: 0
+      weiPaid: 0,
+      isFork: true,
+      parentIndex: index
     }));
     emit PaymentUpdated(index);
     emit PaymentCreated(payments.length - 1);

--- a/contracts/Syndicate.sol
+++ b/contracts/Syndicate.sol
@@ -28,7 +28,7 @@ contract Syndicate {
   Payment[] public payments;
 
   // A mapping of Payment index to forked payments that have been created
-  mapping (uint256 => uint256[]) public forks;
+  mapping (uint256 => uint256[]) public _forks;
 
   event PaymentUpdated(uint256 index);
   event PaymentCreated(uint256 index);
@@ -125,9 +125,14 @@ contract Syndicate {
       isFork: true,
       parentIndex: index
     }));
-    forks[index].push(payments.length - 1);
+    _forks[index].push(payments.length - 1);
     emit PaymentUpdated(index);
     emit PaymentCreated(payments.length - 1);
+  }
+
+  function paymentForkCount(uint256 index) public view returns (uint256) {
+    assertPaymentIndexInRange(index);
+    return _forks[index].length;
   }
 
   /**

--- a/contracts/Syndicate.sol
+++ b/contracts/Syndicate.sol
@@ -28,12 +28,14 @@ contract Syndicate {
 
   event PaymentUpdated(uint256 index);
   event PaymentCreated(uint256 index);
+  event BalanceUpdated(address payable target);
 
   /**
    * Deposit to a given address over a certain amount of time.
    **/
   function deposit(address payable _receiver, uint256 _time) external payable {
     balances[msg.sender] += msg.value;
+    emit BalanceUpdated(msg.sender);
     pay(_receiver, msg.value, _time);
   }
 
@@ -57,6 +59,7 @@ contract Syndicate {
     }));
     // Update the balance value of the sender to effectively lock the funds in place
     balances[msg.sender] -= _weiValue;
+    emit BalanceUpdated(msg.sender);
     emit PaymentCreated(payments.length - 1);
   }
 
@@ -68,6 +71,7 @@ contract Syndicate {
   function paymentSettle(uint256 index) public {
     uint256 owedWei = paymentWeiOwed(index);
     balances[payments[index].receiver] += owedWei;
+    emit BalanceUpdated(payments[index].receiver);
     payments[index].weiPaid += owedWei;
     emit PaymentUpdated(index);
   }
@@ -169,6 +173,7 @@ contract Syndicate {
   function withdraw(address payable target, uint256 weiValue) public {
     require(balances[target] >= weiValue);
     balances[target] -= weiValue;
+    emit BalanceUpdated(target);
     target.transfer(weiValue);
   }
 

--- a/test/syndicate.js
+++ b/test/syndicate.js
@@ -424,4 +424,24 @@ contract('Syndicate', accounts => {
     assert.equal(paymentIndex + 1, forkIndexes[0]);
     assert.equal(paymentIndex + 2, forkIndexes[1]);
   });
+
+  it('isPaymentForked should return correct value', async () => {
+    const _contract = await Syndicate.deployed();
+    const contract = new web3.eth.Contract(_contract.abi, _contract.address);
+    const owner = accounts[0];
+    const weiValue = 5000;
+    const time = 100;
+    await contract.methods.deposit(owner, time).send({
+      from: owner,
+      value: weiValue,
+      gas: 300000
+    });
+    const paymentIndex = await contract.methods.paymentCount().call() - 1;
+    assert.ok(!await contract.methods.isPaymentForked(paymentIndex).call());
+    await contract.methods.paymentFork(paymentIndex, owner, weiValue/1000).send({
+      from: owner,
+      gas: 500000
+    });
+    assert.ok(await contract.methods.isPaymentForked(paymentIndex).call());
+  });
 });

--- a/test/syndicate.js
+++ b/test/syndicate.js
@@ -415,5 +415,15 @@ contract('Syndicate', accounts => {
     assert.ok(fork.isFork);
     assert.equal(fork.parentIndex, paymentIndex);
     assert.ok(!parent.isFork);
+    await contract.methods.paymentFork(paymentIndex, owner, weiValue/1000).send({
+      from: owner,
+      gas: 300000
+    });
+    await contract.methods.paymentFork(paymentIndex, owner, weiValue/1000).send({
+      from: owner,
+      gas: 300000
+    });
+    const forkCount = await contract.methods.paymentForkCount(paymentIndex).call();
+    assert.equal(3, forkCount);
   });
 });

--- a/test/syndicate.js
+++ b/test/syndicate.js
@@ -403,27 +403,25 @@ contract('Syndicate', accounts => {
       gas: 300000
     });
     const paymentIndex = await contract.methods.paymentCount().call() - 1;
-    await new Promise(r => setTimeout(r, 1000 * time / 5))
-    await contract.methods.paymentFork(paymentIndex, owner, weiValue/100).send({
+    await new Promise(r => setTimeout(r, 5000))
+    await contract.methods.paymentFork(paymentIndex, owner, weiValue/1000).send({
       from: owner,
-      gas: 300000
+      gas: 500000
     });
     const parent = await contract.methods.payments(paymentIndex).call();
-    const fork = await contract.methods.payments(paymentIndex + 1).call();
-    assert.ok(weiValue === +parent.weiValue + +fork.weiValue);
-    assert.ok(+parent.timestamp + +parent.time === +fork.timestamp + +fork.time);
-    assert.ok(fork.isFork);
-    assert.equal(fork.parentIndex, paymentIndex);
+    const fork1 = await contract.methods.payments(paymentIndex + 1).call();
+    const fork2 = await contract.methods.payments(paymentIndex + 2).call();
+    assert.ok(weiValue === +parent.weiValue + +fork1.weiValue + +fork2.weiValue);
+    assert.ok(+parent.timestamp + +parent.time === +fork1.timestamp + +fork1.time);
+    assert.ok(+parent.timestamp + +parent.time === +fork2.timestamp + +fork2.time);
+    assert.ok(fork1.isFork);
+    assert.ok(fork2.isFork);
+    assert.equal(fork1.parentIndex, paymentIndex);
+    assert.equal(fork2.parentIndex, paymentIndex);
     assert.ok(!parent.isFork);
-    await contract.methods.paymentFork(paymentIndex, owner, weiValue/1000).send({
-      from: owner,
-      gas: 300000
-    });
-    await contract.methods.paymentFork(paymentIndex, owner, weiValue/1000).send({
-      from: owner,
-      gas: 300000
-    });
-    const forkCount = await contract.methods.paymentForkCount(paymentIndex).call();
-    assert.equal(3, forkCount);
+    assert.ok(await contract.methods.isPaymentSettled(paymentIndex).call());
+    const forkIndexes = await contract.methods.paymentForkIndexes(paymentIndex).call();
+    assert.equal(paymentIndex + 1, forkIndexes[0]);
+    assert.equal(paymentIndex + 2, forkIndexes[1]);
   });
 });

--- a/test/syndicate.js
+++ b/test/syndicate.js
@@ -369,6 +369,9 @@ contract('Syndicate', accounts => {
     });
     const paymentIndex = await contract.methods.paymentCount().call() - 1;
     await new Promise(r => setTimeout(r, 1000 * time / 10));
+    await contract.methods.paymentSettle(paymentIndex).send({
+      from: owner
+    });
     await assert.rejects(contract.methods.paymentFork(paymentIndex, owner, weiValue).send({
       from: owner
     }), 'Should not be able to fork full balance partway into payment');


### PR DESCRIPTION
## Overview

This PR allows payment recipients to fork part (or all) of the value in a payment to another address by settling the original payment at the current point in time, then creating two new payments: one to the original recipient and one to the forked recipient for the requested amount over time.

## Added function

```sol
function paymentFork(uint256 index, address payable _receiver, uint256 _weiValue)
```

## Mechanics

The parent payment has its `weiValue` set equal to its `weiPaid` value thus settling the payment. Two new payments are created, one with the forked `_weiValue` and one with the remaining funds to the original recipient. Both forked payments complete at the same time as the parent payment.

Payment completion times **cannot** be modified but recipient addresses **can** be changed by forking indefinitely (until funds run out). This seems like a nice use of the locked liquidity; it allows delegation of responsibility for funds over time.