### PR TITLE
Delegates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,16 @@ language: node_js
 node_js:
   10
 
-script:
-  - npm run ganache &
-  - npm run coverage
-  - ./scripts/upload_coverage.sh
+jobs:
+  include:
+    - stage: build
+      if: branch != master
+      script:
+        - npm run ganache &
+        - npm run coverage
+    - stage: build
+      if: branch == master
+      script:
+        - npm run ganache &
+        - npm run coverage
+        - ./scripts/upload_coverage.sh

--- a/contracts/Syndicate.sol
+++ b/contracts/Syndicate.sol
@@ -29,6 +29,10 @@ contract Syndicate {
 
   mapping(address => mapping (address => bool)) public delegates;
 
+  /**
+   * Change whether _delegate can settle and fork payments on behalf of
+   * msg.sender.
+   **/
   function delegate(address _delegate, bool delegated) public {
     delegates[msg.sender][_delegate] = delegated;
   }

--- a/contracts/Syndicate.sol
+++ b/contracts/Syndicate.sol
@@ -69,7 +69,7 @@ contract Syndicate {
     require(msg.sender == payment.receiver || delegates[payment.receiver][msg.sender]);
     uint256 owedWei = paymentWeiOwed(index);
     payment.weiPaid += owedWei;
-    msg.sender.transfer(owedWei);
+    payment.receiver.transfer(owedWei);
     emit PaymentUpdated(index);
   }
 
@@ -115,7 +115,7 @@ contract Syndicate {
     emit PaymentUpdated(index);
 
     payments.push(Payment({
-      sender: msg.sender,
+      sender: payment.receiver,
       receiver: _receiver,
       timestamp: block.timestamp,
       time: remainingTime,

--- a/contracts/Syndicate.sol
+++ b/contracts/Syndicate.sol
@@ -66,7 +66,7 @@ contract Syndicate {
   function paymentSettle(uint256 index) public {
     requirePaymentIndexInRange(index);
     Payment storage payment = payments[index];
-    require(msg.sender == payment.receiver || delegates[payment.receiver][msg.sender]);
+    requireExecutionAllowed(payment.receiver);
     uint256 owedWei = paymentWeiOwed(index);
     payment.weiPaid += owedWei;
     payment.receiver.transfer(owedWei);
@@ -100,7 +100,7 @@ contract Syndicate {
     requirePaymentIndexInRange(index);
     Payment storage payment = payments[index];
     // Make sure the payment receiver or a delegate is operating
-    require(msg.sender == payment.receiver || delegates[payment.receiver][msg.sender]);
+    requireExecutionAllowed(payment.receiver);
 
     uint256 remainingWei = payment.weiValue - payment.weiPaid;
     uint256 remainingTime = max(0, payment.time - (block.timestamp - payment.timestamp));
@@ -162,6 +162,13 @@ contract Syndicate {
    **/
   function requirePaymentIndexInRange(uint256 index) public view {
     require(index < payments.length);
+  }
+
+  /**
+   * Checks if msg.sender is allowed to modify payments on behalf of receiver.
+   **/
+  function requireExecutionAllowed(address payable receiver) public view {
+    require(msg.sender == receiver || delegates[receiver][msg.sender] == true);
   }
 
   /**

--- a/test/syndicate.js
+++ b/test/syndicate.js
@@ -285,21 +285,27 @@ contract('Syndicate', accounts => {
     const delegate = accounts[1];
     const weiValue = 5000;
     const time = 100;
-    await contract.methods.delegate(delegate, false);
+    await contract.methods.delegate(delegate, false).send({
+      from: owner,
+      gas: DEFAULT_GAS
+    });
     await contract.methods.paymentCreate(owner, time).send({
       from: owner,
       value: weiValue,
       gas: DEFAULT_GAS
     });
-    const paymentIndex = await contract.methods.paymentCount() - 1;
+    const paymentIndex = await contract.methods.paymentCount().call() - 1;
     await assert.rejects(contract.methods.paymentFork(paymentIndex, owner, weiValue / 2).send({
       from: delegate,
-      gas: DEFAULT_GAS
+      gas: 500000
     }));
-    await contract.methods.delegate(delegate, true);
+    await contract.methods.delegate(delegate, true).send({
+      from: owner,
+      gas: DEFAULT_GAS
+    });
     await contract.methods.paymentFork(paymentIndex, owner, weiValue / 2).send({
       from: delegate,
-      gas: DEFAULT_GAS
+      gas: 500000
     });
   });
 
@@ -310,19 +316,25 @@ contract('Syndicate', accounts => {
     const delegate = accounts[1];
     const weiValue = 5000;
     const time = 100;
-    await contract.methods.delegate(delegate, false);
+    await contract.methods.delegate(delegate, false).send({
+      from: owner,
+      gas: DEFAULT_GAS
+    });
     await contract.methods.paymentCreate(owner, time).send({
       from: owner,
       value: weiValue,
       gas: DEFAULT_GAS
     });
-    const paymentIndex = await contract.methods.paymentCount() - 1;
+    const paymentIndex = await contract.methods.paymentCount().call() - 1;
     await assert.rejects(contract.methods.paymentSettle(paymentIndex).send({
       from: delegate,
       gas: DEFAULT_GAS
     }));
-    await contract.methods.delegate(delegate, true);
-    await contract.methods.paymentFork(paymentIndex).send({
+    await contract.methods.delegate(delegate, true).send({
+      from: owner,
+      gas: DEFAULT_GAS
+    });
+    await contract.methods.paymentSettle(paymentIndex).send({
       from: delegate,
       gas: DEFAULT_GAS
     });

--- a/test/syndicate.js
+++ b/test/syndicate.js
@@ -276,4 +276,54 @@ contract('Syndicate', accounts => {
     assert.equal(paymentIndex + 2, updatedParent.fork2Index);
   });
 
+  it('should delegate forking ability', async () => {
+    const _contract = await Syndicate.deployed();
+    const contract = new web3.eth.Contract(_contract.abi, _contract.address);
+    const owner = accounts[0];
+    const delegate = accounts[1];
+    const weiValue = 5000;
+    const time = 100;
+    await contract.methods.delegate(delegate, false);
+    await contract.methods.paymentCreate(owner, time).send({
+      from: owner,
+      value: weiValue,
+      gas: 300000
+    });
+    const paymentIndex = await contract.methods.paymentCount() - 1;
+    await assert.rejects(contract.methods.paymentFork(paymentIndex, owner, weiValue / 2).send({
+      from: delegate,
+      gas: 300000
+    }));
+    await contract.methods.delegate(delegate, true);
+    await contract.methods.paymentFork(paymentIndex, owner, weiValue / 2).send({
+      from: delegate,
+      gas: 300000
+    });
+  });
+
+  it('should delegate settlement ability', async () => {
+    const _contract = await Syndicate.deployed();
+    const contract = new web3.eth.Contract(_contract.abi, _contract.address);
+    const owner = accounts[0];
+    const delegate = accounts[1];
+    const weiValue = 5000;
+    const time = 100;
+    await contract.methods.delegate(delegate, false);
+    await contract.methods.paymentCreate(owner, time).send({
+      from: owner,
+      value: weiValue,
+      gas: 300000
+    });
+    const paymentIndex = await contract.methods.paymentCount() - 1;
+    await assert.rejects(contract.methods.paymentSettle(paymentIndex).send({
+      from: delegate,
+      gas: 300000
+    }));
+    await contract.methods.delegate(delegate, true);
+    await contract.methods.paymentFork(paymentIndex).send({
+      from: delegate,
+      gas: 300000
+    });
+  });
+
 });

--- a/test/syndicate.js
+++ b/test/syndicate.js
@@ -2,6 +2,8 @@ const Syndicate = artifacts.require('Syndicate');
 const assert = require('assert');
 const BN = require('bn.js');
 
+const DEFAULT_GAS = 300000;
+
 /**
  * Syndicate contract tests
  **/
@@ -21,7 +23,7 @@ contract('Syndicate', accounts => {
     await assert.rejects(contract.methods.paymentCreate(owner, time).send({
       from: owner,
       value: weiValue,
-      gas: 300000
+      gas: DEFAULT_GAS
     }));
   });
 
@@ -46,7 +48,7 @@ contract('Syndicate', accounts => {
     await contract.methods.paymentCreate(owner, time).send({
       from: owner,
       value: weiValue,
-      gas: 300000
+      gas: DEFAULT_GAS
     });
     const paymentIndex = await contract.methods.paymentCount().call() - 1;
     const payment = await contract.methods.payments(paymentIndex).call();
@@ -60,7 +62,7 @@ contract('Syndicate', accounts => {
       // Settle the Payment at the current point in time
       const receipt = await contract.methods.paymentSettle(paymentIndex).send({
         from: owner,
-        gas: 300000,
+        gas: DEFAULT_GAS,
         gasPrice
       });
       const weiCost = new BN(receipt.cumulativeGasUsed).mul(gasPrice);
@@ -94,16 +96,16 @@ contract('Syndicate', accounts => {
     await contract.methods.paymentCreate(receiver, time).send({
       from: owner,
       value: weiValue,
-      gas: 300000
+      gas: DEFAULT_GAS
     });
     const paymentIndex = await contract.methods.paymentCount().call() - 1;
     await assert.rejects(contract.methods.paymentSettle(paymentIndex).send({
       from: owner,
-      gas: 300000
+      gas: DEFAULT_GAS
     }));
     await contract.methods.paymentSettle(paymentIndex).send({
       from: receiver,
-      gas: 300000
+      gas: DEFAULT_GAS
     });
   });
 
@@ -134,7 +136,7 @@ contract('Syndicate', accounts => {
     const time = 1;
     await assert.rejects(contract.methods.paymentCreate(owner, time).send({
       from: owner,
-      gas: 300000
+      gas: DEFAULT_GAS
     }));
   });
 
@@ -166,20 +168,20 @@ contract('Syndicate', accounts => {
     await contract.methods.paymentCreate(owner, time).send({
       from: owner,
       value: 100,
-      gas: 300000
+      gas: DEFAULT_GAS
     });
     const paymentIndex = await contract.methods.paymentCount().call() - 1;
     assert.equal(false, await contract.methods.isPaymentSettled(paymentIndex).call());
     await new Promise(r => setTimeout(r, time * 1000 / 4));
     await contract.methods.paymentSettle(paymentIndex).send({
       from: owner,
-      gas: 300000
+      gas: DEFAULT_GAS
     });
     assert.equal(false, await contract.methods.isPaymentSettled(paymentIndex).call());
     await new Promise(r => setTimeout(r, time * 1000));
     await contract.methods.paymentSettle(paymentIndex).send({
       from: owner,
-      gas: 300000
+      gas: DEFAULT_GAS
     });
     assert.equal(true, await contract.methods.isPaymentSettled(paymentIndex).call());
   });
@@ -194,7 +196,7 @@ contract('Syndicate', accounts => {
     await contract.methods.paymentCreate(targetAddress, time).send({
       from: owner,
       value: weiValue,
-      gas: 300000
+      gas: DEFAULT_GAS
     });
     const paymentIndex = await contract.methods.paymentCount().call() - 1;
     await assert.rejects(contract.methods.paymentFork(paymentIndex, owner, 10).send({
@@ -211,7 +213,7 @@ contract('Syndicate', accounts => {
     await contract.methods.paymentCreate(owner, time).send({
       from: owner,
       value: weiValue,
-      gas: 300000
+      gas: DEFAULT_GAS
     });
     const paymentIndex = await contract.methods.paymentCount().call() - 1;
     await new Promise(r => setTimeout(r, 1000 * time / 10));
@@ -232,7 +234,7 @@ contract('Syndicate', accounts => {
     await contract.methods.paymentCreate(owner, time).send({
       from: owner,
       value: weiValue,
-      gas: 300000
+      gas: DEFAULT_GAS
     });
     const paymentIndex = await contract.methods.paymentCount().call() - 1;
     await assert.rejects(contract.methods.paymentFork(paymentIndex, owner, 0).send({
@@ -249,7 +251,7 @@ contract('Syndicate', accounts => {
     await contract.methods.paymentCreate(owner, time).send({
       from: owner,
       value: weiValue,
-      gas: 300000
+      gas: DEFAULT_GAS
     });
     const paymentIndex = await contract.methods.paymentCount().call() - 1;
     await new Promise(r => setTimeout(r, 5000))
@@ -287,17 +289,17 @@ contract('Syndicate', accounts => {
     await contract.methods.paymentCreate(owner, time).send({
       from: owner,
       value: weiValue,
-      gas: 300000
+      gas: DEFAULT_GAS
     });
     const paymentIndex = await contract.methods.paymentCount() - 1;
     await assert.rejects(contract.methods.paymentFork(paymentIndex, owner, weiValue / 2).send({
       from: delegate,
-      gas: 300000
+      gas: DEFAULT_GAS
     }));
     await contract.methods.delegate(delegate, true);
     await contract.methods.paymentFork(paymentIndex, owner, weiValue / 2).send({
       from: delegate,
-      gas: 300000
+      gas: DEFAULT_GAS
     });
   });
 
@@ -312,17 +314,17 @@ contract('Syndicate', accounts => {
     await contract.methods.paymentCreate(owner, time).send({
       from: owner,
       value: weiValue,
-      gas: 300000
+      gas: DEFAULT_GAS
     });
     const paymentIndex = await contract.methods.paymentCount() - 1;
     await assert.rejects(contract.methods.paymentSettle(paymentIndex).send({
       from: delegate,
-      gas: 300000
+      gas: DEFAULT_GAS
     }));
     await contract.methods.delegate(delegate, true);
     await contract.methods.paymentFork(paymentIndex).send({
       from: delegate,
-      gas: 300000
+      gas: DEFAULT_GAS
     });
   });
 


### PR DESCRIPTION
Adds the ability to delegate fork and settlement operations to other ethereum addresses. Similar to the ERC20 `allowed`.