### PR TITLE
Unix fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ A Syndicate can be used to send a payment over time to an Ethereum address. Bala
 
 Once a payment has been initiated the recipient is able to fork some (or all) of the remaining payment to other addresses. A payment is delegation of responsibility for funds over time.
 
-When a payment is forked the remaining balance is split to two new payments; one to the original recipient, one to the fork target. Child payments complete at the same time as the parent payment, and can be forked again.
+When a payment is forked the original payment `weiValue` is subtracted by the amount being forked. A new payment is created with the desired amount of `weiValue` and a completion time equal to that of the original payment. The forked payment may itself be forked.
 
-Each payment can be represented as a node in a [**full** binary tree](https://en.wikipedia.org/wiki/Binary_tree#Types_of_binary_trees).
+Each payment can be represented as a tree with nodes being individual payments. All payments in a given tree will complete at the same time.
 
 ### Delegation
 

--- a/contracts/Syndicate.sol
+++ b/contracts/Syndicate.sol
@@ -94,8 +94,6 @@ contract Syndicate {
    *
    * Payments can be forked until weiValue is 0, at which point the Payment is
    * settled. Child payments can also be forked.
-   *
-   * The genealogy of a payment can be represented as a binary tree.
    **/
   function paymentFork(uint256 index, address payable _receiver, uint256 _weiValue) public {
     requirePaymentIndexInRange(index);
@@ -134,7 +132,7 @@ contract Syndicate {
   }
 
   /**
-   * Accessor for determining if a given payment is fully settled.
+   * Accessor for determining if a given payment has any forks.
    **/
   function isPaymentForked(uint256 index) public view returns (bool) {
     requirePaymentIndexInRange(index);

--- a/test/syndicate.js
+++ b/test/syndicate.js
@@ -254,28 +254,29 @@ contract('Syndicate', accounts => {
       gas: DEFAULT_GAS
     });
     const paymentIndex = await contract.methods.paymentCount().call() - 1;
+    const parent = await contract.methods.payments(paymentIndex).call();
+    const parentForkCount = await contract.methods.paymentForkCount(paymentIndex).call();
+    assert.equal(+parentForkCount, 0);
     await new Promise(r => setTimeout(r, 5000))
     await contract.methods.paymentFork(paymentIndex, owner, weiValue/1000).send({
       from: owner,
       gas: 500000
     });
-    const parent = await contract.methods.payments(paymentIndex).call();
-    const fork1 = await contract.methods.payments(paymentIndex + 1).call();
-    const fork2 = await contract.methods.payments(paymentIndex + 2).call();
-    assert.ok(weiValue === +parent.weiValue + +fork1.weiValue + +fork2.weiValue);
-    assert.ok(+parent.timestamp + +parent.time === +fork1.timestamp + +fork1.time);
-    assert.ok(+parent.timestamp + +parent.time === +fork2.timestamp + +fork2.time);
-    assert.ok(fork1.isFork);
-    assert.ok(fork2.isFork);
-    assert.equal(fork1.parentIndex, paymentIndex);
-    assert.equal(fork2.parentIndex, paymentIndex);
-    assert.ok(!parent.isFork);
-    assert.ok(await contract.methods.isPaymentSettled(paymentIndex).call());
     const updatedParent = await contract.methods.payments(paymentIndex).call();
-    assert.equal(true, updatedParent.isForked);
-    assert.equal(false, updatedParent.isFork);
-    assert.equal(paymentIndex + 1, updatedParent.fork1Index);
-    assert.equal(paymentIndex + 2, updatedParent.fork2Index);
+    const updatedForkCount = await contract.methods.paymentForkCount(paymentIndex).call();
+    const forkIndex = paymentIndex + 1;
+    const fork = await contract.methods.payments(forkIndex).call();
+    // Lots o' assertions about state variables
+    assert.ok(weiValue === +updatedParent.weiValue + +fork.weiValue);
+    assert.ok(+updatedParent.timestamp + +updatedParent.time === +fork.timestamp + +fork.time);
+    assert.ok(fork.isFork);
+    assert.equal(fork.parentIndex, paymentIndex);
+    assert.ok(!updatedParent.isFork);
+    assert.ok(await contract.methods.isPaymentForked(paymentIndex).call());
+    assert.ok(!await contract.methods.isPaymentSettled(paymentIndex).call());
+    assert.ok(+updatedForkCount === 1);
+    const paymentForkIndex = await contract.methods.paymentForks(paymentIndex, 0).call();
+    assert.ok(+paymentForkIndex, forkIndex)
   });
 
   it('should delegate forking ability', async () => {


### PR DESCRIPTION
This PR changes the forking functionality.

### Old Functionality

Previously a fork settled the parent payment and created two new payments: one to the fork receiver, and one to the original receiver.

### New Functionality

Now a fork mutates the `weiValue` of the original payment and creates a single new payment. A payment can now have multiple forks. This removes the binary tree structure in favor of a more generic tree structure with a single root.

This type of fork functionality is similar to the unix [fork](https://en.wikipedia.org/wiki/Fork_(system_call)) syscall.