### PR TITLE
Remove delegation logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,6 @@ When a payment is forked the original payment `weiValue` is subtracted by the am
 
 Each payment can be represented as a tree with nodes being individual payments. All payments in a given tree will complete at the same time.
 
-### Delegation
-
-The Syndicate includes a `delegate` function that allows an address to delegate the ability to fork and withdraw payments. Forks can be made to any address; withdrawals always go to the payment recipient.
-
 #### Proof
 
 Unit tests cover all functions and logical paths, see the latest build log [here](https://travis-ci.org/common-theory/contracts). Mathematical proofs of functions can be found [here](https://github.com/common-theory/contracts/blob/master/proofs).

--- a/contracts/Syndicate.sol
+++ b/contracts/Syndicate.sol
@@ -112,10 +112,11 @@ contract Syndicate {
       isFork: true,
       parentIndex: index
     }));
-    paymentForks[payments.length - 1] = new uint256[](0);
-    paymentForks[index].push(payments.length - 1);
+    uint256 forkIndex = payments.length - 1;
+    paymentForks[forkIndex] = new uint256[](0);
+    paymentForks[index].push(forkIndex);
     emit PaymentUpdated(index);
-    emit PaymentCreated(payments.length - 1);
+    emit PaymentCreated(forkIndex);
   }
 
   /**

--- a/contracts/Syndicate.sol
+++ b/contracts/Syndicate.sol
@@ -25,16 +25,6 @@ contract Syndicate {
   event PaymentUpdated(uint256 index);
   event PaymentCreated(uint256 index);
 
-  mapping(address => mapping (address => bool)) public delegates;
-
-  /**
-   * Change whether _delegate can settle and fork payments on behalf of
-   * msg.sender.
-   **/
-  function delegate(address _delegate, bool delegated) public {
-    delegates[msg.sender][_delegate] = delegated;
-  }
-
   /**
    * Pay from sender to receiver a certain amount over a certain amount of time.
    **/
@@ -66,7 +56,6 @@ contract Syndicate {
   function paymentSettle(uint256 index) public {
     requirePaymentIndexInRange(index);
     Payment storage payment = payments[index];
-    requireExecutionAllowed(payment.receiver);
     uint256 owedWei = paymentWeiOwed(index);
     payment.weiPaid += owedWei;
     payment.receiver.transfer(owedWei);
@@ -97,8 +86,8 @@ contract Syndicate {
   function paymentFork(uint256 index, address payable _receiver, uint256 _weiValue) public {
     requirePaymentIndexInRange(index);
     Payment storage payment = payments[index];
-    // Make sure the payment receiver or a delegate is operating
-    requireExecutionAllowed(payment.receiver);
+    // Make sure the payment receiver is operating
+    require(msg.sender == payment.receiver);
 
     uint256 remainingWei = payment.weiValue - payment.weiPaid;
     uint256 remainingTime = max(0, payment.time - (block.timestamp - payment.timestamp));
@@ -158,13 +147,6 @@ contract Syndicate {
    **/
   function requirePaymentIndexInRange(uint256 index) public view {
     require(index < payments.length);
-  }
-
-  /**
-   * Checks if msg.sender is allowed to modify payments on behalf of receiver.
-   **/
-  function requireExecutionAllowed(address payable receiver) public view {
-    require(msg.sender == receiver || delegates[receiver][msg.sender] == true);
   }
 
   /**

--- a/test/syndicate.js
+++ b/test/syndicate.js
@@ -86,7 +86,7 @@ contract('Syndicate', accounts => {
     assert.ok(await contract.methods.isPaymentSettled(paymentIndex));
   });
 
-  it('should fail to settle if not receiver', async () => {
+  it('should settle if not receiver', async () => {
     const _contract = await Syndicate.deployed();
     const contract = new web3.eth.Contract(_contract.abi, _contract.address);
     const owner = accounts[0];
@@ -99,10 +99,10 @@ contract('Syndicate', accounts => {
       gas: DEFAULT_GAS
     });
     const paymentIndex = await contract.methods.paymentCount().call() - 1;
-    await assert.rejects(contract.methods.paymentSettle(paymentIndex).send({
+    await contract.methods.paymentSettle(paymentIndex).send({
       from: owner,
       gas: DEFAULT_GAS
-    }));
+    });
     await contract.methods.paymentSettle(paymentIndex).send({
       from: receiver,
       gas: DEFAULT_GAS
@@ -277,68 +277,6 @@ contract('Syndicate', accounts => {
     assert.ok(+updatedForkCount === 1);
     const paymentForkIndex = await contract.methods.paymentForks(paymentIndex, 0).call();
     assert.ok(+paymentForkIndex, forkIndex)
-  });
-
-  it('should delegate forking ability', async () => {
-    const _contract = await Syndicate.deployed();
-    const contract = new web3.eth.Contract(_contract.abi, _contract.address);
-    const owner = accounts[0];
-    const delegate = accounts[1];
-    const weiValue = 5000;
-    const time = 100;
-    await contract.methods.delegate(delegate, false).send({
-      from: owner,
-      gas: DEFAULT_GAS
-    });
-    await contract.methods.paymentCreate(owner, time).send({
-      from: owner,
-      value: weiValue,
-      gas: DEFAULT_GAS
-    });
-    const paymentIndex = await contract.methods.paymentCount().call() - 1;
-    await assert.rejects(contract.methods.paymentFork(paymentIndex, owner, weiValue / 2).send({
-      from: delegate,
-      gas: 500000
-    }));
-    await contract.methods.delegate(delegate, true).send({
-      from: owner,
-      gas: DEFAULT_GAS
-    });
-    await contract.methods.paymentFork(paymentIndex, owner, weiValue / 2).send({
-      from: delegate,
-      gas: 500000
-    });
-  });
-
-  it('should delegate settlement ability', async () => {
-    const _contract = await Syndicate.deployed();
-    const contract = new web3.eth.Contract(_contract.abi, _contract.address);
-    const owner = accounts[0];
-    const delegate = accounts[1];
-    const weiValue = 5000;
-    const time = 100;
-    await contract.methods.delegate(delegate, false).send({
-      from: owner,
-      gas: DEFAULT_GAS
-    });
-    await contract.methods.paymentCreate(owner, time).send({
-      from: owner,
-      value: weiValue,
-      gas: DEFAULT_GAS
-    });
-    const paymentIndex = await contract.methods.paymentCount().call() - 1;
-    await assert.rejects(contract.methods.paymentSettle(paymentIndex).send({
-      from: delegate,
-      gas: DEFAULT_GAS
-    }));
-    await contract.methods.delegate(delegate, true).send({
-      from: owner,
-      gas: DEFAULT_GAS
-    });
-    await contract.methods.paymentSettle(paymentIndex).send({
-      from: delegate,
-      gas: DEFAULT_GAS
-    });
   });
 
 });


### PR DESCRIPTION
The delegation logic in the Syndicate contract is unnecessary and can be moved to an external contract.

In the contract below multiple addresses can be delegated for manipulating payments to the deployed `Delegate` contract:

```sol
pragma solidity ^0.5.0;

import './Syndicate.sol';

contract Delegate {
  address syndicateAddress;
  address payable owner;
  
  mapping(address => bool) delegates;

  constructor(address _syndicateAddress) public {
    syndicateAddress = _syndicateAddress;
    delegates[msg.sender] = true;
  }

  function delegate(address _delegate, bool delegated) public {
    require(delegates[msg.sender] == true);
    delegates[_delegate] = delegated;  
  }

  function paymentFork(uint256 index, address payable _receiver, uint256 _weiValue) public {
     require(delegates[msg.sender] == true);
     Syndicate syndicate = Syndicate(syndicateAddress);
     syndicate.paymentFork(index, _receiver, _weiValue);
  }
}
```